### PR TITLE
core feat: Step functionality

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,32 +1,41 @@
-import startServer from "./server";
-import functions from "./services/fn";
+import startServer from './server';
+import functions from './services/fn';
 
 const func1 = functions.createFunction({
-  id: "first-function",
-  event: "event1",
+  id: 'first-function',
+  event: 'event1',
   fn: async () => {
-    console.log("Hello world");
+    console.log('Hello world');
   },
 });
 const func2 = functions.createFunction({
-  id: "second-function",
-  event: "event1",
+  id: 'second-function',
+  event: 'event1',
   fn: async () => {
-    console.log("Hi :)");
+    console.log('Hi :)');
   },
 });
 
 const func3 = functions.createFunction({
-  id: "third-function",
-  event: "event2",
+  id: 'third-function',
+  event: 'event2',
   fn: async (event) => {
     if (
       !!event.payload &&
-      "url" in event.payload &&
-      typeof event.payload.url === "string"
+      'url' in event.payload &&
+      typeof event.payload.url === 'string'
     ) {
       fetch(event.payload.url);
     }
+  },
+});
+
+const func4 = functions.createFunction({
+  id: 'step-function',
+  event: 'event3',
+  fn: async (event, step) => {
+    await step.run('phone person', async () => console.log('phone person'));
+    await step.run('email person', async () => console.log('email person'));
   },
 });
 

--- a/functions/src/routes/calls.ts
+++ b/functions/src/routes/calls.ts
@@ -38,14 +38,20 @@ router.post('/', async (req, res: Response<RpcResponse>) => {
   }
 
   try {
-    const result = await fn.fn(params.event, new Step({}));
+    const result = await fn.fn(params.event, new Step(params.cache));
     if (id) {
-      body = { result, id };
+      body = {
+        id,
+        result: {
+          type: 'complete',
+        },
+      };
     }
   } catch (e) {
     if (!id) {
       body = undefined;
     } else if (e instanceof StepComplete) {
+      if (e.stepValue === undefined) e.stepValue = null;
       body = {
         id,
         result: { type: 'step', stepId: e.stepId, stepValue: e.stepValue },

--- a/functions/src/routes/calls.ts
+++ b/functions/src/routes/calls.ts
@@ -1,22 +1,23 @@
-import express, { Response } from "express";
-import { RpcResponse } from "../types/types";
-import functions from "../services/fn";
-import { isValidRpcRequest } from "../utils/utils";
+import express, { Response } from 'express';
+import { RpcResponse } from '../types/types';
+import functions from '../services/fn';
+import { isValidRpcRequest } from '../utils/utils';
+import { Step, StepComplete } from '../utils/step';
 
 const router = express.Router();
 
 router.use(express.json());
 
-router.post("/", (req, res: Response<RpcResponse>) => {
+router.post('/', async (req, res: Response<RpcResponse>) => {
   if (!isValidRpcRequest(req.body)) {
     if (
       !!req.body &&
-      typeof req.body === "object" &&
-      "id" in req.body &&
-      (typeof req.body.id === "string" || typeof req.body.id === "number")
+      typeof req.body === 'object' &&
+      'id' in req.body &&
+      (typeof req.body.id === 'string' || typeof req.body.id === 'number')
     ) {
       return res.status(400).json({
-        error: "Not a valid JSON RPC request format",
+        error: 'Not a valid JSON RPC request format',
         id: req.body.id,
       });
     }
@@ -37,13 +38,19 @@ router.post("/", (req, res: Response<RpcResponse>) => {
   }
 
   try {
-    fn.fn(params.event);
-    const result = undefined;
+    const result = await fn.fn(params.event, new Step({}));
     if (id) {
       body = { result, id };
     }
   } catch (e) {
-    if (id && (e instanceof Error || typeof e === "string")) {
+    if (!id) {
+      body = undefined;
+    } else if (e instanceof StepComplete) {
+      body = {
+        id,
+        result: { type: 'step', stepId: e.stepId, stepValue: e.stepValue },
+      };
+    } else if (e instanceof Error || typeof e === 'string') {
       body = { error: e, id };
     }
   }

--- a/functions/src/types/types.ts
+++ b/functions/src/types/types.ts
@@ -2,7 +2,7 @@ import { Step } from '../utils/step';
 export interface RpcRequest {
   jsonrpc: '2.0';
   method: string;
-  params: { event: Event };
+  params: { event: Event; cache: { [key: string]: any } };
   id?: number | string;
 }
 

--- a/functions/src/types/types.ts
+++ b/functions/src/types/types.ts
@@ -1,3 +1,4 @@
+import { Step } from '../utils/step';
 export interface RpcRequest {
   jsonrpc: '2.0';
   method: string;
@@ -11,7 +12,7 @@ export interface RpcResponse {
   id: number | string;
 }
 
-export type EventFunction = (event: Event) => Promise<void>;
+export type EventFunction = (event: Event, step: Step) => Promise<any>;
 
 export interface FunctionData {
   id: string;

--- a/functions/src/utils/step.ts
+++ b/functions/src/utils/step.ts
@@ -1,0 +1,26 @@
+export class Step {
+  #cache: { [key: string]: any };
+
+  constructor(cache: { [key: string]: any }) {
+    this.#cache = cache;
+  }
+
+  async run(id: string, callback: () => Promise<any>) {
+    if (id in this.#cache) {
+      return this.#cache[id];
+    }
+    const result = await callback();
+    throw new StepComplete(id, result);
+  }
+}
+
+export class StepComplete extends Error {
+  stepId: string;
+  stepValue: any;
+
+  constructor(stepId: string, stepValue: any) {
+    super(`Not an error: ${stepId} completed`);
+    this.stepId = stepId;
+    this.stepValue = stepValue;
+  }
+}

--- a/functions/src/utils/utils.ts
+++ b/functions/src/utils/utils.ts
@@ -25,6 +25,9 @@ export const isValidRpcRequest = (body: unknown): body is RpcRequest => {
     isValidEvent(body.params.event) &&
     (!('id' in body) ||
       typeof body.id === 'number' ||
-      typeof body.id === 'string')
+      typeof body.id === 'string') &&
+    'cache' in body.params &&
+    typeof body.params.cache === 'object' &&
+    !!body.params.cache
   );
 };

--- a/workers/tasks/process-event.ts
+++ b/workers/tasks/process-event.ts
@@ -30,7 +30,7 @@ const process_event: Task = async function (event, helpers) {
     ).rows.map((obj) => obj.name);
 
     names.forEach((funcId) => {
-      helpers.addJob('process_job', { name: funcId, event });
+      helpers.addJob('process_job', { name: funcId, event, cache: {} });
     });
   } finally {
     client.release();

--- a/workers/tasks/process-job.ts
+++ b/workers/tasks/process-job.ts
@@ -1,45 +1,62 @@
-import dotenv from "dotenv";
+import dotenv from 'dotenv';
 dotenv.config();
 
-import { Task } from "graphile-worker";
-import { isValidFunctionPayload, isValidRpcResponse } from "../utils/utils";
-import { v4 as uuidv4 } from "uuid";
+import { Task } from 'graphile-worker';
+import { isValidFunctionPayload, isValidRpcResponse } from '../utils/utils';
+import { v4 as uuidv4 } from 'uuid';
 
-const functionServerUrl: string = process.env.FUNCTION_SERVER_URL ?? "";
+const functionServerUrl: string = process.env.FUNCTION_SERVER_URL ?? '';
 if (!functionServerUrl) {
-  console.error("No function server URL found");
+  console.error('No function server URL found');
 }
 
-const process_job: Task = async function (job) {
+const process_job: Task = async function (job, helpers) {
   if (!isValidFunctionPayload(job)) {
     throw new Error(`${job} not valid Function Payload`);
   }
 
-  const result = await fetch(functionServerUrl, {
-    method: "POST",
+  const response = await fetch(functionServerUrl, {
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      jsonrpc: "2.0",
+      jsonrpc: '2.0',
       method: job.name,
       id: uuidv4(),
-      params: { event: job.event },
+      params: { event: job.event, cache: job.cache },
     }),
   });
 
-  let data = await result.json();
+  let data = await response.json();
 
   if (!isValidRpcResponse(data)) {
-    throw new Error("Not a valid response");
+    throw new Error('Not a valid response');
   }
 
-  if ("error" in data) {
-    if (typeof data.error === "string") {
+  if ('error' in data) {
+    if (typeof data.error === 'string') {
       throw new Error(data.error);
     } else {
       throw data.error;
     }
+  }
+
+  if (!data.result) {
+    return;
+  }
+
+  const result = data.result;
+  switch (result.type) {
+    case 'complete':
+      return;
+    case 'step':
+      job.cache[result.stepId] = result.stepValue;
+      helpers.addJob('process_job', job);
+      break;
+    default:
+      const _exhaustiveCheck: never = result;
+      return _exhaustiveCheck;
   }
 };
 

--- a/workers/types/types.ts
+++ b/workers/types/types.ts
@@ -6,10 +6,11 @@ export interface Event {
 export interface FunctionPayload {
   name: string;
   event: Event;
+  cache: { [key: string]: any };
 }
 
 export interface RpcResponse {
-  result?: object;
+  result?: CompleteResult | StepResult;
   error?: Error | string;
   id: number | string;
 }
@@ -19,4 +20,16 @@ export interface Secret {
   password: string;
   host: string;
   port: number;
+}
+
+export interface CompleteResult {
+  type: 'complete';
+  stepId: string;
+  stepValue: any;
+}
+
+export interface StepResult {
+  type: 'step';
+  stepId: string;
+  stepValue: any;
 }

--- a/workers/utils/utils.ts
+++ b/workers/utils/utils.ts
@@ -1,11 +1,17 @@
-import { Event, FunctionPayload, RpcResponse } from "../types/types";
+import {
+  Event,
+  FunctionPayload,
+  RpcResponse,
+  CompleteResult,
+  StepResult,
+} from '../types/types';
 
 export const isValidEvent = (event: unknown): event is Event => {
   return (
     !!event &&
-    typeof event === "object" &&
-    "name" in event &&
-    typeof event.name === "string"
+    typeof event === 'object' &&
+    'name' in event &&
+    typeof event.name === 'string'
   );
 };
 
@@ -14,24 +20,50 @@ export const isValidFunctionPayload = (
 ): payload is FunctionPayload => {
   return (
     !!payload &&
-    typeof payload === "object" &&
-    "name" in payload &&
-    typeof payload.name === "string" &&
-    "event" in payload &&
-    isValidEvent(payload.event)
+    typeof payload === 'object' &&
+    'name' in payload &&
+    typeof payload.name === 'string' &&
+    'event' in payload &&
+    isValidEvent(payload.event) &&
+    'cache' in payload &&
+    typeof payload.cache === 'object' &&
+    !!payload.cache
   );
 };
 
 export const isValidRpcResponse = (body: unknown): body is RpcResponse => {
   return (
     !!body &&
-    typeof body === "object" &&
-    "id" in body &&
-    (typeof body.id === "number" || typeof body.id === "string") &&
-    (!("result" in body) ||
-      (!!body.result && typeof body.result === "object")) &&
-    (!("error" in body) ||
-      typeof body.error === "string" ||
+    typeof body === 'object' &&
+    'id' in body &&
+    (typeof body.id === 'number' || typeof body.id === 'string') &&
+    (!('result' in body) ||
+      (!!body.result &&
+        (isValidCompleteResult(body.result) ||
+          isValidStepResult(body.result)))) &&
+    (!('error' in body) ||
+      typeof body.error === 'string' ||
       body.error instanceof Error)
+  );
+};
+
+const isValidCompleteResult = (result: unknown): result is CompleteResult => {
+  return (
+    !!result &&
+    typeof result === 'object' &&
+    'type' in result &&
+    result.type === 'complete'
+  );
+};
+
+const isValidStepResult = (result: unknown): result is StepResult => {
+  return (
+    !!result &&
+    typeof result === 'object' &&
+    'type' in result &&
+    result.type === 'step' &&
+    'stepId' in result &&
+    typeof result.stepId === 'string' /*&&
+    'stepValue' in result/*/
   );
 };


### PR DESCRIPTION
feat: Implemented step functionality by:
- Adding a cache to job payloads on the graphile queue
- Creating two initial types of RPC response results for the Graphile job processing worker to process: "completed" (indicating a function has fully run) and "step" (indicating the function has more steps yet to run)
- Having the job processing worker enqueue jobs with an updated cache for subsequent steps

No PR review necessary as all members were present for the mob programming session.