### PR TITLE
Logging error trace

### DIFF
--- a/functions/src/routes/calls.ts
+++ b/functions/src/routes/calls.ts
@@ -88,7 +88,7 @@ router.post('/', async (req, res: Response<RpcResponse>) => {
         },
       };
     } else if (e instanceof Error) {
-      body = { error: e.message, id };
+      body = { error: JSON.stringify(e, Object.getOwnPropertyNames(e)), id };
     } else if (typeof e === 'string') {
       body = { error: e, id };
     }

--- a/sample/src/index.ts
+++ b/sample/src/index.ts
@@ -1,40 +1,40 @@
-import dotenv from "dotenv";
+import dotenv from 'dotenv';
 dotenv.config();
-import functionsExportType from "@reverb-app/functions";
+import functionsExportType from '@reverb-app/functions';
 import(
-  process.env.NODE_ENV === "development"
-    ? "../../functions/src"
-    : "@reverb-app/functions"
+  process.env.NODE_ENV === 'development'
+    ? '../../functions/src'
+    : '@reverb-app/functions'
 ).then(
   (
     server: typeof functionsExportType | { default: typeof functionsExportType }
   ) => {
-    server = "default" in server ? server.default : server;
+    server = 'default' in server ? server.default : server;
 
     const func1 = server.createFunction({
-      id: "first-function",
-      event: "event1",
+      id: 'first-function',
+      event: 'event1',
       fn: async () => {
-        console.log("Hello world");
+        console.log('Hello world');
       },
     });
 
     const func2 = server.createFunction({
-      id: "second-function",
-      event: "event1",
+      id: 'second-function',
+      event: 'event1',
       fn: async () => {
-        console.log("Hi :)");
+        console.log('Hi :)');
       },
     });
 
     const func3 = server.createFunction({
-      id: "third-function",
-      event: "event2",
+      id: 'third-function',
+      event: 'event2',
       fn: async (event) => {
         if (
           !!event.payload &&
-          "url" in event.payload &&
-          typeof event.payload.url === "string"
+          'url' in event.payload &&
+          typeof event.payload.url === 'string'
         ) {
           fetch(event.payload.url);
         }
@@ -42,42 +42,50 @@ import(
     });
 
     const func4 = server.createFunction({
-      id: "step-function",
-      event: "event3",
+      id: 'step-function',
+      event: 'event3',
       fn: async (event, step) => {
-        await step.run("phone person", async () => console.log("phone person"));
-        await step.delay("some delay", "1m30s");
-        await step.run("email person", async () => console.log("email person"));
+        await step.run('phone person', async () => console.log('phone person'));
+        await step.delay('some delay', '1m30s');
+        await step.run('email person', async () => console.log('email person'));
       },
     });
 
     const func5 = server.createFunction({
-      id: "function-calls-function",
-      event: "event4",
+      id: 'function-calls-function',
+      event: 'event4',
       fn: async (event, step) => {
-        await step.invoke("call 3rd function", "third-function", {
-          url: "https://enaeajsfdm4b.x.pipedream.net/",
+        await step.invoke('call 3rd function', 'third-function', {
+          url: 'https://enaeajsfdm4b.x.pipedream.net/',
         });
       },
     });
 
     const func6 = server.createFunction({
-      id: "emit-event-function",
-      event: "event5",
+      id: 'emit-event-function',
+      event: 'event5',
       fn: async (event, step) => {
-        await step.emitEvent("emit-event2", "event2", {
-          url: "https://enaeajsfdm4b.x.pipedream.net/",
+        await step.emitEvent('emit-event2', 'event2', {
+          url: 'https://enaeajsfdm4b.x.pipedream.net/',
         });
       },
     });
 
     const func7 = server.createFunction({
-      id: "cron-function",
-      cron: "*/4 * * * *",
+      id: 'cron-function',
+      cron: '*/4 * * * *',
       fn: async (event, step) => {
-        await step.invoke("call 3rd function", "third-function", {
-          url: "https://enaeajsfdm4b.x.pipedream.net/",
+        await step.invoke('call 3rd function', 'third-function', {
+          url: 'https://enaeajsfdm4b.x.pipedream.net/',
         });
+      },
+    });
+
+    const func8 = server.createFunction({
+      id: 'error-function',
+      event: 'event6',
+      fn: async () => {
+        throw new Error('This error is for testing purposes');
       },
     });
 

--- a/sample/src/index.ts
+++ b/sample/src/index.ts
@@ -83,7 +83,7 @@ import(
 
     const func8 = server.createFunction({
       id: 'error-function',
-      event: 'event6',
+      event: 'error',
       fn: async () => {
         throw new Error('This error is for testing purposes');
       },

--- a/workers/tasks/process_job.ts
+++ b/workers/tasks/process_job.ts
@@ -99,8 +99,6 @@ const process_job: Task = async function (job, helpers) {
         max_attempts,
       });
 
-      console.log(logMessage);
-
       throw e;
     } else {
       log.error('RPC Response contains an error.', {

--- a/workers/tasks/process_job.ts
+++ b/workers/tasks/process_job.ts
@@ -9,13 +9,21 @@ import log from '../utils/logUtils';
 
 const functionServerUrl: string = process.env.FUNCTION_SERVER_URL ?? '';
 if (!functionServerUrl) {
-  log.error('No function server URL found');
+  throw new Error('No function server URL found');
 }
 
 const process_job: Task = async function (job, helpers) {
+  const { payload, attempts, max_attempts } = helpers.job;
+
   if (!isValidFunctionPayload(job)) {
-    log.error('Not a valid Function Payload', helpers.job);
-    throw new Error(`${job} not valid Function Payload`);
+    const e = new Error(`${job} not valid Function Payload`);
+    log.error('Not a valid Function Payload', {
+      error: e,
+      payload,
+      attempts,
+      max_attempts,
+    });
+    throw e;
   }
   let data: any;
   try {
@@ -38,27 +46,72 @@ const process_job: Task = async function (job, helpers) {
       funcId: job.id,
       eventId: job.event.id,
       error: e,
+      payload,
+      attempts,
+      max_attempts,
     });
+    if (e instanceof Error)
+      e.message = 'Error communicating with function server';
     throw e;
   }
 
   if (!isValidRpcResponse(data)) {
+    const e = new Error(
+      'Did not receive a valid RPC response from function server'
+    );
+
     log.error('Did not receive a valid RPC response from function server', {
       funcId: job.id,
       eventId: job.event.id,
       response: data,
+      error: e,
+      payload,
+      attempts,
+      max_attempts,
     });
-    throw new Error('Not a valid RPC response');
+
+    throw e;
   }
   if ('error' in data) {
-    log.error('RPC Response contains an error.', {
-      funcId: job.id,
-      eventid: job.event.id,
-      error: data.error,
-    });
     if (typeof data.error === 'string') {
-      throw new Error(data.error);
+      let e;
+      let logMessage = 'RPC Response contains an error.';
+
+      try {
+        const parsed = JSON.parse(data.error);
+        if ('message' in parsed && 'stack' in parsed) {
+          e = new Error(parsed.message);
+          e.stack = parsed.stack;
+        }
+      } catch {}
+
+      if (!e) {
+        e = new Error(data.error);
+        logMessage = 'RPC Response contains an improperly formatted error.';
+      }
+
+      log.error(logMessage, {
+        funcId: job.id,
+        eventid: job.event.id,
+        error: e,
+        payload,
+        attempts,
+        max_attempts,
+      });
+
+      console.log(logMessage);
+
+      throw e;
     } else {
+      log.error('RPC Response contains an error.', {
+        funcId: job.id,
+        eventid: job.event.id,
+        error: data.error,
+        payload,
+        attempts,
+        max_attempts,
+      });
+
       throw data.error;
     }
   }
@@ -112,7 +165,7 @@ const process_job: Task = async function (job, helpers) {
         },
         cache: {},
       });
-      log.info('Invoked function', {
+      log.info('Invoked function as step', {
         funcId: funcId,
         eventId: job.event.id,
         funcName: result.invokedFnName,

--- a/workers/tests/process-event.test.ts
+++ b/workers/tests/process-event.test.ts
@@ -33,19 +33,23 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+const mockHelpers = {
+  job: {
+    payload: {},
+    attempts: 0,
+    max_attempts: 0,
+  },
+} as JobHelpers;
+
 test('incorrect event throws an error', () => {
-  expect(() =>
-    process_event(incorrectEventOne, {} as JobHelpers)
-  ).rejects.toThrow();
-  expect(() =>
-    process_event(incorrectEventTwo, {} as JobHelpers)
-  ).rejects.toThrow();
+  expect(() => process_event(incorrectEventOne, mockHelpers)).rejects.toThrow();
+  expect(() => process_event(incorrectEventTwo, mockHelpers)).rejects.toThrow();
 });
 
 describe('Logger', () => {
   test('logs an error on incorrect job', async () => {
     try {
-      await process_event(incorrectEventOne, {} as JobHelpers);
+      await process_event(incorrectEventOne, mockHelpers);
     } catch {
     } finally {
       expect(log.error).toHaveBeenCalled();
@@ -56,7 +60,7 @@ describe('Logger', () => {
     await process_event(correctEvent, {
       addJob: () => {},
       query: () => {
-        return { rows: [{ name: 'test_function' }] };
+        return { job: mockHelpers.job, rows: [{ name: 'test_function' }] };
       },
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
@@ -65,7 +69,10 @@ describe('Logger', () => {
   test('logs a warning when event has no functions', async () => {
     await process_event(correctEvent, {
       query: () => {
-        return { rows: [] };
+        return {
+          job: mockHelpers.job,
+          rows: [],
+        };
       },
     } as unknown as JobHelpers);
 
@@ -77,6 +84,7 @@ describe('Logger', () => {
       addJob: () => {},
       query: () => {
         return {
+          job: mockHelpers.job,
           rows: [{ name: 'test_function1' }, { name: 'test_function2' }],
         };
       },

--- a/workers/tests/process-job.test.ts
+++ b/workers/tests/process-job.test.ts
@@ -33,18 +33,22 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
+const mockHelpers = {
+  job: {
+    payload: {},
+    attempts: 0,
+    max_attempts: 0,
+  },
+} as JobHelpers;
+
 test('incorrect job throws an error', () => {
-  expect(() =>
-    process_job(incorrectJobOne, {} as JobHelpers)
-  ).rejects.toThrow();
-  expect(() =>
-    process_job(incorrectJobTwo, {} as JobHelpers)
-  ).rejects.toThrow();
+  expect(() => process_job(incorrectJobOne, mockHelpers)).rejects.toThrow();
+  expect(() => process_job(incorrectJobTwo, mockHelpers)).rejects.toThrow();
 });
 
 test("throws an error when it can't connect to Function server", () => {
   global.fetch = jest.fn(() => Promise.reject(new Error('failed')));
-  expect(() => process_job(correctJob, {} as JobHelpers)).rejects.toThrow();
+  expect(() => process_job(correctJob, mockHelpers)).rejects.toThrow();
 });
 
 test('throws an error when invalid RPCResponse', () => {
@@ -55,7 +59,7 @@ test('throws an error when invalid RPCResponse', () => {
       },
     })
   ) as jest.Mock;
-  expect(() => process_job(correctJob, {} as JobHelpers)).rejects.toThrow();
+  expect(() => process_job(correctJob, mockHelpers)).rejects.toThrow();
 });
 
 test('throws an error on valid RPCResponse that has an error property', () => {
@@ -70,7 +74,7 @@ test('throws an error on valid RPCResponse that has an error property', () => {
       },
     })
   ) as jest.Mock;
-  expect(() => process_job(correctJob, {} as JobHelpers)).rejects.toThrow();
+  expect(() => process_job(correctJob, mockHelpers)).rejects.toThrow();
 });
 
 test('does not throw an error on valid RPC response that has a result property', async () => {
@@ -90,7 +94,7 @@ test('does not throw an error on valid RPC response that has a result property',
     })
   ) as jest.Mock;
 
-  (process_job(correctJob, {} as JobHelpers) as Promise<void>).then((val) =>
+  (process_job(correctJob, mockHelpers) as Promise<void>).then((val) =>
     expect(val).toBeUndefined()
   );
 });
@@ -98,7 +102,7 @@ test('does not throw an error on valid RPC response that has a result property',
 describe('Logger', () => {
   test('logs an error on incorrect job', async () => {
     try {
-      await process_job(incorrectJobOne, {} as JobHelpers);
+      await process_job(incorrectJobOne, mockHelpers);
     } catch {
     } finally {
       expect(log.error).toHaveBeenCalled();
@@ -108,7 +112,7 @@ describe('Logger', () => {
   test("logs an error when it can't connect to Function server", async () => {
     global.fetch = jest.fn(() => Promise.reject(new Error('failed')));
     try {
-      await process_job(correctJob, {} as JobHelpers);
+      await process_job(correctJob, mockHelpers);
     } catch {
     } finally {
       expect(log.error).toHaveBeenCalled();
@@ -125,7 +129,7 @@ describe('Logger', () => {
     ) as jest.Mock;
 
     try {
-      await process_job(correctJob, {} as JobHelpers);
+      await process_job(correctJob, mockHelpers);
     } catch {
     } finally {
       expect(log.error).toHaveBeenCalled();
@@ -146,7 +150,7 @@ describe('Logger', () => {
     ) as jest.Mock;
 
     try {
-      await process_job(correctJob, {} as JobHelpers);
+      await process_job(correctJob, mockHelpers);
     } catch {
     } finally {
       expect(log.error).toHaveBeenCalled();
@@ -165,7 +169,7 @@ describe('Logger', () => {
       })
     ) as jest.Mock;
 
-    await process_job(correctJob, {} as JobHelpers);
+    await process_job(correctJob, mockHelpers);
     expect(log.warn).toHaveBeenCalled();
   });
 
@@ -184,7 +188,7 @@ describe('Logger', () => {
       })
     ) as jest.Mock;
 
-    await process_job(correctJob, {} as JobHelpers);
+    await process_job(correctJob, mockHelpers);
     expect(log.info).toHaveBeenCalled();
   });
 
@@ -207,6 +211,7 @@ describe('Logger', () => {
 
     await process_job(correctJob, {
       addJob: () => {},
+      job: mockHelpers.job,
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
   });
@@ -230,6 +235,7 @@ describe('Logger', () => {
 
     await process_job(correctJob, {
       addJob: () => {},
+      job: mockHelpers.job,
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
   });
@@ -253,6 +259,7 @@ describe('Logger', () => {
 
     await process_job(correctJob, {
       addJob: () => {},
+      job: mockHelpers.job,
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
   });
@@ -276,6 +283,7 @@ describe('Logger', () => {
 
     await process_job(correctJob, {
       addJob: () => {},
+      job: mockHelpers.job,
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
   });

--- a/workers/utils/logUtils.ts
+++ b/workers/utils/logUtils.ts
@@ -1,7 +1,7 @@
 import winston from 'winston';
 import 'winston-mongodb';
 
-const { combine, timestamp, json, simple } = winston.format;
+const { combine, timestamp, json, simple, metadata } = winston.format;
 
 let mongoConnectionString = process.env.MONGO_CONNECTION_STRING as string;
 const secret = process.env.MONGO_SECRET;
@@ -13,9 +13,11 @@ if (secret) {
 
 const log = winston.createLogger({
   level: 'info',
-  format: combine(timestamp(), json()),
+  format: combine(timestamp(), json(), metadata()),
   transports: [
-    new winston.transports.Console({ format: combine(timestamp(), simple()) }),
+    new winston.transports.Console({
+      format: combine(timestamp(), simple(), metadata()),
+    }),
     new winston.transports.MongoDB({
       db: mongoConnectionString,
       collection: 'log',

--- a/workers/utils/logUtils.ts
+++ b/workers/utils/logUtils.ts
@@ -11,6 +11,11 @@ if (secret) {
   mongoConnectionString = `mongodb://${user.username}:${user.password}@${url}`;
 }
 
+const mongoTransport = new winston.transports.MongoDB({
+  db: mongoConnectionString,
+  collection: 'log',
+});
+
 const log = winston.createLogger({
   level: 'info',
   format: combine(timestamp(), json(), metadata()),
@@ -18,11 +23,9 @@ const log = winston.createLogger({
     new winston.transports.Console({
       format: combine(timestamp(), simple(), metadata()),
     }),
-    new winston.transports.MongoDB({
-      db: mongoConnectionString,
-      collection: 'log',
-    }),
+    mongoTransport,
   ],
+  exceptionHandlers: [mongoTransport],
 });
 
 export default log;


### PR DESCRIPTION
Updated logging behavior in relation to error-handling:
* The function server now sends a full stack trace to the workers server, which the workers server parses, logs, and throws.
* Implemented the MongoDB transport as an exception handler in Winston, allowing full stack traces to be automatically logged when the worker server throws an uncaught error. As of right now, this is only applicable if the function server URL is not set properly.
* Updated all current error logs to include the payload, attempt number, and max attempts from the Graphile Worker helper.
* Updated tests.