### PR TITLE
fix: Fixed filter to use the right timestamp property.

### DIFF
--- a/ingress/src/routes/logs.ts
+++ b/ingress/src/routes/logs.ts
@@ -111,7 +111,7 @@ router.get("/events/:eventId", async (req: Request, res) => {
       "meta.eventId": eventId,
     });
 
-    statusLogs.forEach(log => {
+    statusLogs.forEach((log) => {
       if (!log._id) return;
       let status = "running";
       if (log.message === "Function completed") {
@@ -161,7 +161,7 @@ router.get("/functions/status", async (req: Request, res) => {
 
   try {
     const logs = await getAggregate(group, filter);
-    const statusReport = logs.map(log => {
+    const statusReport = logs.map((log) => {
       let status = "running";
       if (log.message === "Function completed") {
         status = "completed";

--- a/ingress/src/types/types.ts
+++ b/ingress/src/types/types.ts
@@ -1,4 +1,4 @@
-import { ObjectId } from 'mongodb';
+import { ObjectId } from "mongodb";
 export interface Event {
   name: string;
   payload?: Object;
@@ -34,7 +34,7 @@ export interface QueryFilter {
   level?: "info" | "warn" | "debug" | "error" | "silly" | "http" | "verbose";
   _id?: { $gt: ObjectId };
   "meta.eventId"?: string;
-  "meta.timestamp"?: { $gte: Date; $lte: Date };
+  timestamp?: { $gte: Date; $lte: Date };
   "meta.funcId"?: string | { $in: string[] };
 }
 export interface AggregateGroup {

--- a/ingress/src/utils/loggingUtils.ts
+++ b/ingress/src/utils/loggingUtils.ts
@@ -1,5 +1,5 @@
 import { client, dbName } from "../services/mongo-service";
-import { ObjectId } from 'mongodb';
+import { ObjectId } from "mongodb";
 import { Request } from "express";
 import { isValidTimeParams } from "../utils/utils";
 import { QueryFilter, AggregateGroup } from "types/types";
@@ -9,19 +9,18 @@ const DEFAULT_PAGE = 1;
 
 export async function getOffsetPaginatedLogs(
   offset: number,
-  limit: number,
+  limit: number | undefined,
   filter: {} = {},
   sort: {} = {}
 ): Promise<any[]> {
   try {
     const database = client.db(dbName);
     const collection = database.collection("logs");
-    const logs = await collection
-      .find(filter)
-      .sort(sort)
-      .skip(offset)
-      .limit(limit)
-      .toArray();
+    let search = await collection.find(filter).sort(sort).skip(offset);
+    if (limit) {
+      search = await search.limit(limit);
+    }
+    const logs = await search.toArray();
     return logs;
   } catch (error) {
     throw new Error("Error retrieving logs from MongoDB");
@@ -59,12 +58,18 @@ export async function getAggregate(group: AggregateGroup, filter: QueryFilter) {
 
 export function handleOffsetPagination(req: Request): {
   page: number;
-  limit: number;
+  limit?: number;
   offset: number;
 } {
-  let limit = parseInt(req.query.limit as string) || DEFAULT_LIMIT;
+  let limit: number | undefined =
+    parseInt(req.query.limit as string) || DEFAULT_LIMIT;
+
+  if (limit === -1) {
+    limit = undefined;
+  }
+
   const page = parseInt(req.query.page as string) || DEFAULT_PAGE;
-  const offset = (page - 1) * limit;
+  const offset = (page - 1) * (limit ?? 0);
 
   return { page, limit, offset };
 }
@@ -94,7 +99,7 @@ export function setFilterTimestamp(req: Request, filter: QueryFilter) {
   }
 
   if (queryTimestamp.startTime && queryTimestamp.endTime) {
-    filter["meta.timestamp"] = {
+    filter["timestamp"] = {
       $gte: new Date(queryTimestamp.startTime),
       $lte: new Date(queryTimestamp.endTime),
     };


### PR DESCRIPTION
Fixed a bug where the filter was using $meta.timestamp instead of $timestamp.
$meta.timestamp is a string, while $timestamp is a date construct which can be filtered.