### PR TITLE
change: Changed /functions to return just function status objects.

### DIFF
--- a/ingress/src/routes/logs.ts
+++ b/ingress/src/routes/logs.ts
@@ -81,7 +81,7 @@ router.get("/functions", async (req: Request, res) => {
   try {
     const { page, limit, offset } = handleOffsetPagination(req);
 
-    const status = await getFunctionsStatus(filter, limit, offset);
+    const status = await getFunctionsStatus(filter, offset, limit);
 
     if (status.length === 0 && page !== 1) {
       return res.status(404).json({ error: "Page not found" });

--- a/ingress/src/utils/loggingUtils.ts
+++ b/ingress/src/utils/loggingUtils.ts
@@ -64,7 +64,11 @@ export async function getFunctionsStatus(
   const database = client.db(dbName);
   const collection = database.collection("logs");
   let search = await collection
-    .aggregate([{ $match: filter }, { $group: group }])
+    .aggregate([
+      { $match: filter },
+      { $sort: { timestamp: 1 } },
+      { $group: group },
+    ])
     .skip(offset);
 
   if (limit) {
@@ -73,7 +77,9 @@ export async function getFunctionsStatus(
 
   let logs = await search.toArray();
 
-  logs = logs.filter((log) => log._id !== null);
+  logs = logs
+    .filter((log) => log._id !== null)
+    .sort((a, b) => Date.parse(b.invoked) - Date.parse(a.invoked));
 
   return logs.map((log) => {
     let status = "running";

--- a/ingress/src/utils/loggingUtils.ts
+++ b/ingress/src/utils/loggingUtils.ts
@@ -1,5 +1,5 @@
 import { client, dbName } from "../services/mongo-service";
-import { ObjectId } from 'mongodb';
+import { ObjectId } from "mongodb";
 import { Request } from "express";
 import { isValidTimeParams } from "../utils/utils";
 import { QueryFilter, AggregateGroup } from "types/types";
@@ -71,7 +71,9 @@ export async function getFunctionsStatus(
     search = await search.limit(limit);
   }
 
-  const logs = await search.toArray();
+  let logs = await search.toArray();
+
+  logs = logs.filter((log) => log._id !== null);
 
   return logs.map((log) => {
     let status = "running";


### PR DESCRIPTION
Changed /logs/functions to return an array of Function Status objects instead of individual logs for function invocation and function complete messages. This makes it consistent with the other routes that give functions status.

The /logs/functions/:id route still gives all logs related to that function.