### PR TITLE
feat: Dead letter functionality - workers server

### DIFF
--- a/workers/tasks/process_cron.ts
+++ b/workers/tasks/process_cron.ts
@@ -1,5 +1,6 @@
 import { Task } from "graphile-worker";
 import { v4 } from "uuid";
+import { MAX_ATTEMPTS } from "../utils/deadLetterUtils";
 import log from "../utils/logUtils";
 import { isValidCronPayload } from "../utils/utils";
 
@@ -10,12 +11,16 @@ const process_cron: Task = async function (cronJob, helpers) {
   }
 
   const funcId = v4();
-  helpers.addJob("process_job", {
-    name: cronJob.funcName,
-    id: funcId,
-    event: { name: "cron", id: "" },
-    cache: {},
-  });
+  helpers.addJob(
+    "process_job",
+    {
+      name: cronJob.funcName,
+      id: funcId,
+      event: { name: "cron", id: "" },
+      cache: {},
+    },
+    { maxAttempts: MAX_ATTEMPTS }
+  );
 
   log.info("Function invoked", {
     funcId,

--- a/workers/tasks/process_event.ts
+++ b/workers/tasks/process_event.ts
@@ -1,6 +1,7 @@
 import { Task } from "graphile-worker";
 import { isValidEvent } from "../utils/utils";
 import { v4 } from "uuid";
+import { MAX_ATTEMPTS } from "../utils/deadLetterUtils";
 import log from "../utils/logUtils";
 
 const process_event: Task = async function (event, helpers) {
@@ -27,12 +28,16 @@ const process_event: Task = async function (event, helpers) {
 
     names.forEach(funcName => {
       const funcId = v4();
-      helpers.addJob("process_job", {
-        name: funcName,
-        event,
-        id: funcId,
-        cache: {},
-      });
+      helpers.addJob(
+        "process_job",
+        {
+          name: funcName,
+          event,
+          id: funcId,
+          cache: {},
+        },
+        { maxAttempts: MAX_ATTEMPTS }
+      );
       log.info("Function invoked", { eventId: event.id, funcName, funcId });
     });
   } catch (e) {

--- a/workers/tasks/process_event.ts
+++ b/workers/tasks/process_event.ts
@@ -11,7 +11,8 @@ const process_event: Task = async function (event, helpers) {
 
     return handleRetries(
       helpers.job,
-      new Error(`${event} is not a valid event`)
+      new Error(`${event} is not a valid event`),
+      true
     );
   }
 

--- a/workers/tasks/process_job.ts
+++ b/workers/tasks/process_job.ts
@@ -25,7 +25,7 @@ const process_job: Task = async function (job, helpers) {
       max_attempts,
     });
 
-    return handleRetries(helpers.job, e);
+    return handleRetries(helpers.job, e, true);
   }
 
   let data: any;

--- a/workers/types/types.ts
+++ b/workers/types/types.ts
@@ -69,4 +69,4 @@ export interface EmitEventResult {
   payload?: object;
 }
 
-export type DeadLetterType = "function" | "event";
+export type DeadLetterType = "job" | "event";

--- a/workers/types/types.ts
+++ b/workers/types/types.ts
@@ -68,3 +68,5 @@ export interface EmitEventResult {
   eventId: string;
   payload?: object;
 }
+
+export type DeadLetterType = "function" | "event";

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -15,8 +15,8 @@ export const handleRetries = (
     } else message = "Dead letter: Max attempts limit reached";
 
     log.error(message, {
-      dead_letter: true,
-      task_type: job.task_identifier === "process_event" ? "event" : "job",
+      isDeadLetter: true,
+      taskType: job.task_identifier === "process_event" ? "event" : "job",
       error,
       payload: job.payload,
       attempts: job.attempts,

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -1,0 +1,17 @@
+import log from "./logUtils";
+import { Job } from "graphile-worker";
+
+export const MAX_ATTEMPTS = 20;
+
+export const handleRetries = (job: Job, error: Error): void => {
+  if (job.attempts === job.max_attempts) {
+    log.error("Job has reached max attempts limit", {
+      error,
+      payload: job.payload,
+      attempts: job.attempts,
+      max_attempts: job.max_attempts,
+    });
+  } else {
+    throw error;
+  }
+};

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -17,8 +17,8 @@ export const handleRetries = (job: Job, error: Error): void => {
 
     log.error(message, {
       dead_letter: true,
-      error,
       task_type,
+      error,
       payload: job.payload,
       attempts: job.attempts,
       max_attempts: job.max_attempts,

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -15,7 +15,6 @@ export const handleRetries = (
     } else message = "Dead letter: Max attempts limit reached";
 
     log.error(message, {
-      isDeadLetter: true,
       taskType: job.task_identifier === "process_event" ? "event" : "job",
       error,
       payload: job.payload,

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -1,23 +1,22 @@
 import log from "./logUtils";
 import { Job } from "graphile-worker";
-import { DeadLetterType } from "../types/types";
-import { isValidFunctionPayload, isValidEvent } from "./utils";
 
 export const MAX_ATTEMPTS = 20;
 
-export const handleRetries = (job: Job, error: Error): void => {
-  let task_type: DeadLetterType = "job";
-  if (job.task_identifier === "process_event") task_type = "event";
-
-  if (isDeadLetter(job, task_type)) {
+export const handleRetries = (
+  job: Job,
+  error: Error,
+  isInvalidPayload?: true
+): void => {
+  if (isDeadLetter(job, isInvalidPayload)) {
     let message: string;
-    if (job.attempts === job.max_attempts) {
-      message = "Dead letter: Max attempts limit reached";
-    } else message = "Dead letter: Invalid payload";
+    if (isInvalidPayload) {
+      message = "Dead letter: Invalid payload";
+    } else message = "Dead letter: Max attempts limit reached";
 
     log.error(message, {
       dead_letter: true,
-      task_type,
+      task_type: job.task_identifier === "process_event" ? "event" : "job",
       error,
       payload: job.payload,
       attempts: job.attempts,
@@ -28,14 +27,9 @@ export const handleRetries = (job: Job, error: Error): void => {
   }
 };
 
-const isValidPayload = (type: DeadLetterType, payload: unknown): boolean => {
-  if (type === "event" && isValidEvent(payload)) return true;
-  if (type === "job" && isValidFunctionPayload(payload)) return true;
-  return false;
-};
-
-const isDeadLetter = (job: Job, type: DeadLetterType): boolean => {
-  return (
-    !isValidPayload(type, job.payload) || job.attempts === job.max_attempts
-  );
+const isDeadLetter = (
+  job: Job,
+  isInvalidPayload: true | undefined
+): boolean => {
+  return isInvalidPayload || job.attempts >= job.max_attempts;
 };

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -6,11 +6,17 @@ import { isValidFunctionPayload, isValidEvent } from "./utils";
 export const MAX_ATTEMPTS = 20;
 
 export const handleRetries = (job: Job, error: Error): void => {
-  let task_type: DeadLetterType = "function";
+  let task_type: DeadLetterType = "job";
   if (job.task_identifier === "process_event") task_type = "event";
 
-  if (job.attempts === job.max_attempts) {
-    log.error("Max attempts limit reached", {
+  if (isDeadLetter(job, task_type)) {
+    let message: string;
+    if (job.attempts === job.max_attempts) {
+      message = "Dead letter: Max attempts limit reached";
+    } else message = "Dead letter: Invalid payload";
+
+    log.error(message, {
+      dead_letter: true,
       error,
       task_type,
       payload: job.payload,
@@ -20,4 +26,16 @@ export const handleRetries = (job: Job, error: Error): void => {
   } else {
     throw error;
   }
+};
+
+const isValidPayload = (type: DeadLetterType, payload: unknown): boolean => {
+  if (type === "event" && isValidEvent(payload)) return true;
+  if (type === "job" && isValidFunctionPayload(payload)) return true;
+  return false;
+};
+
+const isDeadLetter = (job: Job, type: DeadLetterType): boolean => {
+  return (
+    !isValidPayload(type, job.payload) || job.attempts === job.max_attempts
+  );
 };

--- a/workers/utils/deadLetterUtils.ts
+++ b/workers/utils/deadLetterUtils.ts
@@ -1,12 +1,18 @@
 import log from "./logUtils";
 import { Job } from "graphile-worker";
+import { DeadLetterType } from "../types/types";
+import { isValidFunctionPayload, isValidEvent } from "./utils";
 
 export const MAX_ATTEMPTS = 20;
 
 export const handleRetries = (job: Job, error: Error): void => {
+  let task_type: DeadLetterType = "function";
+  if (job.task_identifier === "process_event") task_type = "event";
+
   if (job.attempts === job.max_attempts) {
-    log.error("Job has reached max attempts limit", {
+    log.error("Max attempts limit reached", {
       error,
+      task_type,
       payload: job.payload,
       attempts: job.attempts,
       max_attempts: job.max_attempts,


### PR DESCRIPTION
### Dead Letter Functionality on the Workers Server

Dead letter event and job payloads will now be logged to the Mongo database.
- `handleRetries` in the `deadLetterUtils` module is responsible for logging dead letters. Jobs become dead letters if they've hit their max attempts or have an invalid payload format, meaning they will never be successfully processed. If the job is not a dead letter, `handleRetries` will simply throw an error to fail the attempt.

 - The function takes three arguments: 
    - `job`: the job's metadata from `helpers.job`
    - `error`: the error to be thrown if the job is not dead lettered, and stored in the `error` field of the log document if it is
    - `isInValidPayload?`: indicates that this job's payload was formatted incorrectly, and thus should be dead lettered immediately

- The message on the log document will be `"Dead letter: Invalid payload"` or `"Dead letter: Max attempts limit reached"`
- The `taskType` on the log document will be `"event"` or `"job"` depending on whether the job was being processed by `process_event` or `process_job`

- `deadLetterUtils` also exposes a `MAX_ATTEMPTS` value, which is now configured via the `maxAttempts` field of the third argument to every job enqueued from within `process_job`, `process_event`, and `process_cron`