### PR TITLE
test: Workers testing fixes and cron tests

### DIFF
--- a/functions/src/routes/calls.ts
+++ b/functions/src/routes/calls.ts
@@ -37,7 +37,7 @@ router.post("/", async (req, res: Response<RpcResponse>) => {
 
   if (!fn) {
     if (id) {
-      body = { error: `Method ${method} does not exist.`, id };
+      body = { error: `RPC failed: Method ${method} does not exist.`, id };
     }
 
     return res.status(404).json(body);

--- a/workers/tests/process-cron.test.ts
+++ b/workers/tests/process-cron.test.ts
@@ -77,3 +77,17 @@ test("addJob is called with the correct arguments", async () => {
     { maxAttempts: 20 }
   );
 });
+
+test("logs an error on incorrect job", async () => {
+  try {
+    await process_cron(funcPayload, mockHelpers);
+  } catch {
+  } finally {
+    expect(log.error).toHaveBeenCalledTimes(1);
+  }
+});
+
+test("logs on function payload enqueued", async () => {
+  await process_cron(validCronJob, mockHelpers);
+  expect(log.info).toHaveBeenCalledTimes(1);
+});

--- a/workers/tests/process-cron.test.ts
+++ b/workers/tests/process-cron.test.ts
@@ -1,0 +1,56 @@
+import process_cron from "../tasks/process_cron";
+import { JobHelpers } from "graphile-worker";
+import { CronPayload, Event, FunctionPayload } from "../types/types";
+import log from "../utils/logUtils";
+
+const validCronJob: CronPayload = { funcName: "my-function" };
+
+const funcPayload: FunctionPayload = {
+  name: "my-function",
+  id: "uuid1234567891011121314",
+  event: { name: "event1", id: "uuid1234567891011121315" },
+  cache: {},
+};
+
+const eventPayload: Event = {
+  name: "event1",
+  id: "uuid1234567891011121315",
+  payload: { test: true },
+};
+
+jest.mock("../utils/logUtils", () => {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+});
+
+jest.spyOn(log, "info");
+jest.spyOn(log, "warn");
+jest.spyOn(log, "error");
+
+const mockHelpers = {
+  job: {
+    payload: {},
+    attempts: 0,
+    max_attempts: 0,
+  },
+} as JobHelpers;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("incorrect cron job throws an error", () => {
+  expect(() => process_cron(funcPayload, mockHelpers)).rejects.toThrow(
+    /Cron format is not valid/
+  );
+  expect(() => process_cron(eventPayload, mockHelpers)).rejects.toThrow(
+    /Cron format is not valid/
+  );
+});
+
+// test("correct cron job does not throw an error", () => {
+//   expect(() => process_cron(validCronJob, {}));
+// });

--- a/workers/tests/process-cron.test.ts
+++ b/workers/tests/process-cron.test.ts
@@ -74,7 +74,7 @@ test("addJob is called with the correct arguments", async () => {
       event: { name: "cron", id: "" },
       cache: {},
     }),
-    { maxAttempts: 20 }
+    { maxAttempts: expect.any(Number) }
   );
 });
 

--- a/workers/tests/process-event.test.ts
+++ b/workers/tests/process-event.test.ts
@@ -41,7 +41,7 @@ const mockHelpers = {
   },
 } as JobHelpers;
 
-test("incorrect event dead letter queues and resolves", () => {
+test("invalid event format dead letter queues and resolves", () => {
   expect(
     process_event(incorrectEventOne, mockHelpers)
   ).resolves.toBeUndefined();

--- a/workers/tests/process-event.test.ts
+++ b/workers/tests/process-event.test.ts
@@ -1,12 +1,12 @@
-import process_event from '../tasks/process_event';
-import { JobHelpers } from 'graphile-worker';
-import { v4 } from 'uuid';
-import log from '../utils/logUtils';
+import process_event from "../tasks/process_event";
+import { JobHelpers } from "graphile-worker";
+import { v4 } from "uuid";
+import log from "../utils/logUtils";
 
 const correctEvent = {
-  name: 'test_event',
+  name: "test_event",
   id: v4(),
-  payload: { key: 'value' },
+  payload: { key: "value" },
 };
 
 const incorrectEventOne = {
@@ -14,10 +14,10 @@ const incorrectEventOne = {
 };
 
 const incorrectEventTwo = {
-  name: 'test_event',
+  name: "test_event",
 };
 
-jest.mock('../utils/logUtils', () => {
+jest.mock("../utils/logUtils", () => {
   return {
     info: () => {},
     warn: () => {},
@@ -25,9 +25,9 @@ jest.mock('../utils/logUtils', () => {
   };
 });
 
-jest.spyOn(log, 'info');
-jest.spyOn(log, 'warn');
-jest.spyOn(log, 'error');
+jest.spyOn(log, "info");
+jest.spyOn(log, "warn");
+jest.spyOn(log, "error");
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -41,13 +41,16 @@ const mockHelpers = {
   },
 } as JobHelpers;
 
-test('incorrect event throws an error', () => {
-  expect(() => process_event(incorrectEventOne, mockHelpers)).rejects.toThrow();
-  expect(() => process_event(incorrectEventTwo, mockHelpers)).rejects.toThrow();
+test("incorrect event dead letter queues and resolves", () => {
+  expect(
+    process_event(incorrectEventOne, mockHelpers)
+  ).resolves.toBeUndefined();
+
+  expect(log.error).toHaveBeenCalledTimes(2);
 });
 
-describe('Logger', () => {
-  test('logs an error on incorrect job', async () => {
+describe("Logger", () => {
+  test("logs an error on incorrect job", async () => {
     try {
       await process_event(incorrectEventOne, mockHelpers);
     } catch {
@@ -56,17 +59,17 @@ describe('Logger', () => {
     }
   });
 
-  test('logs on event complete', async () => {
+  test("logs on event complete", async () => {
     await process_event(correctEvent, {
       addJob: () => {},
       query: () => {
-        return { job: mockHelpers.job, rows: [{ name: 'test_function' }] };
+        return { job: mockHelpers.job, rows: [{ name: "test_function" }] };
       },
     } as unknown as JobHelpers);
     expect(log.info).toHaveBeenCalled();
   });
 
-  test('logs a warning when event has no functions', async () => {
+  test("logs a warning when event has no functions", async () => {
     await process_event(correctEvent, {
       query: () => {
         return {
@@ -79,13 +82,13 @@ describe('Logger', () => {
     expect(log.warn).toHaveBeenCalled();
   });
 
-  test('logs for each function invoked by event', async () => {
+  test("logs for each function invoked by event", async () => {
     await process_event(correctEvent, {
       addJob: () => {},
       query: () => {
         return {
           job: mockHelpers.job,
-          rows: [{ name: 'test_function1' }, { name: 'test_function2' }],
+          rows: [{ name: "test_function1" }, { name: "test_function2" }],
         };
       },
     } as unknown as JobHelpers);


### PR DESCRIPTION
### Testing fixes
With the implementation of `deadLetterUtils` and `handleRetries`, our old tests for `process_job` and `process_event` broke. I updated those to be able to handle the new conditions in which errors are thrown or not. 
- I also updated the mock data for `process_job` to have a higher `maxAttempts` so it wouldn't immediately be dead lettered in tests.

### process_cron tests
Implemented tests for the `process_cron` task. 
- Test that invalid cron format throws an error (these are not dead letter queued like the other tasks)
- Test that `helpers.addJob` is called with a function payload drawn from `funcName` from the cron payload argument
- Test that errors and info are logged appropriately
